### PR TITLE
Taubel

### DIFF
--- a/src/network/network_common.h
+++ b/src/network/network_common.h
@@ -33,8 +33,8 @@ extern "C" {
     #endif
 #endif
 
-#ifdef LWM2M_WITH_DTLS
 #include "mbedtls/ssl.h"
+#ifdef LWM2M_WITH_DTLS
 #include "mbedtls/ssl_cookie.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"

--- a/src/network/network_lwip.c
+++ b/src/network/network_lwip.c
@@ -225,7 +225,7 @@ connection_t * internal_connection_create(network_t* network,
                                  uint16_t port)
 {
     ip_addr_t addr;
-    memset((&addr, 0, sizeof(addr_t)));
+    memset(&addr, 0, sizeof(addr_t));
     if (!ipaddr_aton(host, &addr))
     {
         return 0;

--- a/src/network/network_lwip.c
+++ b/src/network/network_lwip.c
@@ -225,7 +225,7 @@ connection_t * internal_connection_create(network_t* network,
                                  uint16_t port)
 {
     ip_addr_t addr;
-    memset(&addr, 0, sizeof(addr_t));
+    memset((void*)&addr, 0, sizeof(addr_t));
     if (!ipaddr_aton(host, &addr))
     {
         return 0;

--- a/src/network/network_lwip.c
+++ b/src/network/network_lwip.c
@@ -81,6 +81,7 @@ void udp_raw_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_
 
     // Find connection with given address (or create it in server mode)
     addr_t t;
+    memset((void*)&t, 0, sizeof(addr_t));
     t.port = port;
     t.addr = *addr;
     connection_t * connection = internal_connection_find(network, t);
@@ -224,6 +225,7 @@ connection_t * internal_connection_create(network_t* network,
                                  uint16_t port)
 {
     ip_addr_t addr;
+    memset((&addr, 0, sizeof(addr_t)));
     if (!ipaddr_aton(host, &addr))
     {
         return 0;

--- a/src/platform/platform_esp8266sdk.c
+++ b/src/platform/platform_esp8266sdk.c
@@ -25,6 +25,9 @@ typedef int make_iso_compilers_happy; // if not ESP8266
 #include "os_type.h"
 #include "user_interface.h"
 
+static time_t prev = 0, curr = 0;
+static u32 offset_count = 0;
+
 void * lwm2m_malloc(size_t s)
 {
     return (void*)malloc(s);
@@ -49,8 +52,15 @@ int lwm2m_strncmp(const char * s1,
 
 time_t lwm2m_gettime(void)
 {
+    prev = curr;
     // Convert system time in us to s.
-    return system_get_time()/1000/1000;
+    curr = return system_get_time()/1000/1000 + offset_count * 4295;
+    if(prev > curr)
+    {
+        offset_count++;
+	curr+-4295;
+    }
+    return curr;
 }
 
 #ifdef LWM2M_WITH_LOGS


### PR DESCRIPTION
After developing a program for an ESP8266 module for some time I have a few suggestions on how to improve the code. Firstly the code won't compile if "LWM2M_WITH_DTLS" is not defined, because then the "ssl.h" header doesn't get included and symbols like "MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL" stay undefined, causing compilation errors when compiling "network_lwip.c", function "mbedtls_net_send".

Also, I suggest "memset" for same measure. I have run into problems after the device receives a reply from a server. In "udp_raw_recv" declaring structure "t" without defining "net_if_out" causes it to be defined as a random number, probably because of leftovers from the previous stack. This in turn causes "if(connection->addr.net_if_out)" statement in function "mbedtls_net_send" to be true, so the program calls "udp_sendto_if" because the network interface is specified, when in reality it is not. This later causes undefined behavior in the lwip stack, usually ending in a crash, when it tries to execute a function at address "0x0000000" or similar.

The "lwm2m_get_time" function uses some internal 32bit esp buffer, running at 1MHz, so after around 70 minutes the buffer overflows, and the client registration update mechanism stops working, because suddenly "current" time is lower than "previous" time