### PR TITLE
Changes for pull request

### DIFF
--- a/src/network/network_lwip.c
+++ b/src/network/network_lwip.c
@@ -34,7 +34,7 @@ typedef int make_iso_compilers_happy; // if not LWIP
 #include "lwip/dns.h"
 
 // it is either timers.h or since Jul 19, 2016 timeouts.h
-#include "lwip/timeouts.h"
+//#include "lwip/timeouts.h"
 //#include "lwip/timers.h"
 
 void udp_raw_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port);

--- a/src/platform/platform_freertos.c
+++ b/src/platform/platform_freertos.c
@@ -33,7 +33,10 @@ void lwm2m_free(void * p)
 
 char * lwm2m_strdup(const char * str)
 {
-    char *dupStr = (char*)pvPortMalloc(sizeof(str));
+    size_t len = strlen(str);
+    if(!len)
+	return 0;
+    char *dupStr = (char*)pvPortMalloc(len + 1);
     strcpy(dupStr, str);
 	return dupStr;
 }


### PR DESCRIPTION
A few issues I have noticed while building the program on a freertos platform.

First of all, "timeouts.h" seems to be not needed by the application, only by the source files in "/test" and "/contrib". In my case, the header "timeouts.h" isn't even included in the platform's I am working on framework.

The next problem is with trying to find out the size of a string with the "sizeof()" method. In this case the string is a pointer, so the method only returns the size of a pointer, which depends on the platform, not the actual length of the string.

Also, I have had problems with object templates in the "objects.h" file. I can't tell if this is a problem with Wakama library, or the framework. Compiling code included from any of the object header's (for example 3312.h) causes the "delete" method in objects.h:255 to be called, because there can't be found a template for instance resources "int Dimmer" and "int OnTime", even though there is a template for "int32_t" types in objects.h:354. This might be caused because of "int" type ambiguity in different platforms, but I am not sure.